### PR TITLE
Fix typo in generator to make Rails 3.2 development caching work

### DIFF
--- a/hobo/lib/generators/hobo/setup_wizard/setup_wizard_generator.rb
+++ b/hobo/lib/generators/hobo/setup_wizard/setup_wizard_generator.rb
@@ -238,7 +238,7 @@ EOI
 
     def active_reload_dryml
       environment "#", :env => :development
-      environment "config.watchable_dirs[File.join(config.root, 'app/view')] = ['dryml']", :env => :development
+      environment "config.watchable_dirs[File.join(config.root, 'app/views')] = ['dryml']", :env => :development
       environment "# Hobo: tell ActiveReload about dryml", :env => :development
     end
 


### PR DESCRIPTION
I found a typo in the watchable dirs generator. I had to change app/view to app/views to make it work.
