### PR TITLE
Using Ajax with transition-buttons in Hobo 2.0 pre7

### DIFF
--- a/hobo_rapid/app/helpers/hobo_rapid_helper.rb
+++ b/hobo_rapid/app/helpers/hobo_rapid_helper.rb
@@ -168,7 +168,7 @@ module HoboRapidHelper
                      end
 
         unless method == "get"
-          page_path = if (request.post? || request.put? || request.delete?) && params[:page_path]
+          page_path = if params[:page_path]
                         params[:page_path]
                       else
                         request.fullpath

--- a/integration_tests/agility_bootstrap/test/integration/ajax_form_test.rb
+++ b/integration_tests/agility_bootstrap/test/integration/ajax_form_test.rb
@@ -49,7 +49,10 @@ class AjaxFormTest < ActionDispatch::IntegrationTest
     Capybara.current_driver = :selenium_chrome
     Capybara.default_wait_time = 10
     visit root_path
-
+    
+    # Resize the window so Bootstrap shows Login button
+    Capybara.current_session.driver.browser.manage.window.resize_to(1024,700)
+    
     # log in as Administrator
     click_link "Login"
     fill_in "login", :with => "admin@example.com"


### PR DESCRIPTION
When using Ajax, the transition-button does not work. Example:

``` xml
<show-page:>

  <prepend-content-body:>
    <h3>Without Ajax (it works)</h3>
    <transition-buttons/>

    <h3>With Ajax (it does not work)</h3>
    <div part="mypart">
      <transition-buttons ajax/>  
    </div>
  </prepend-content-body:>

</show-page:>
```

After some debugging I found out that the server is detecting the call as GET, instead of PUT. It looks like the HTML generated for Ajax requests is not setting the method correctly. I made a small workaround to the transition-button tag to force the method and action:

``` diff
diff --git a/hobo_rapid/taglibs/buttons/transition_button.dryml b/hobo_rapid/taglibs/buttons/transition_button.dryml
index 6a7f3b3..df47c1a 100644
--- a/hobo_rapid/taglibs/buttons/transition_button.dryml
+++ b/hobo_rapid/taglibs/buttons/transition_button.dryml
@@ -50,9 +50,9 @@ If the transition could not be found, the user does not have permissions for the

     if (!ajax_attributes.empty?) && !has_params
       ajax_attributes[:message] ||= label
-      ajax_attributes[:method] = html_attributes[:method]
-    %><form lifecycle="&transition_name" merge-attrs="&ajax_attributes" class="button_to" param>
+    %><form action="&object_url(this, transition_name)" method="post" lifecycle="&transition_name" merge-attrs="&ajax_attributes" class="button_to" param>
         <input type="hidden" name="key" value="&this.lifecycle.provided_key" if="&this.lifecycle.provided_key"/>
+        <input type="hidden" name="_method" value="put"/>
         <submit label="&label" merge-attributes="&html_attributes" param="button"/>
       </form><%
     else %><%=

```

I suspect I might be breaking some other use cases. What do you think?
