### PR TITLE
hobo-cache keys are too long for filesystem storage

### DIFF
--- a/hobo_rapid/app/helpers/hobo_cache_helper.rb
+++ b/hobo_rapid/app/helpers/hobo_cache_helper.rb
@@ -23,7 +23,8 @@ module HoboCacheHelper
       key_attrs["#{qp}"] = params[qp] || ""
     end
 
-    ActiveSupport::Cache.expand_cache_key(url_for(key_attrs).split('://').last, namespace)
+    key = ActiveSupport::Cache.expand_cache_key(url_for(key_attrs).split('://').last, namespace)
+    Digest::MD5.hexdigest(key)
   end
 
   def item_cache(*args, &block)


### PR DESCRIPTION
I noticed that while this works:

``` xml
<hobo-cache updated="&this.updated_at">
```

This breaks with a "Filename too long" error:

``` xml
<hobo-cache suffix="form" updated="&this.updated_at">
```

Seeing that Rails is using the filesystem as storage for the keys as default in production environment, I was wondering if Hobo should use a hash of the key as default. I made a quick patch to hobo_cache_helper.rb and I haven't seen any side effects:

``` diff
diff --git a/hobo_rapid/app/helpers/hobo_cache_helper.rb b/hobo_rapid/app/helpers/hobo_cache_helper.rb
index 5e92f2a..d260970 100644
--- a/hobo_rapid/app/helpers/hobo_cache_helper.rb
+++ b/hobo_rapid/app/helpers/hobo_cache_helper.rb
@@ -23,7 +23,8 @@ module HoboCacheHelper

-    ActiveSupport::Cache.expand_cache_key(url_for(key_attrs).split('://').last, namespace)
+    key = ActiveSupport::Cache.expand_cache_key(url_for(key_attrs).split('://').last, namespace)
+    Digest::MD5.hexdigest(key)
   end
```

Maybe it would be better to make it an option, something like:

``` xml
<hobo-cache suffix="form" updated="&this.updated_at" md5="true">
```

What do you think?
