### PR TITLE
Make methodphitamine's It inherit from BlankSlate

### DIFF
--- a/hobo_support/lib/hobo_support/methodphitamine.rb
+++ b/hobo_support/lib/hobo_support/methodphitamine.rb
@@ -9,9 +9,7 @@ module Kernel
 
 end
 
-class It
-
-  instance_methods.reject { |m| m =~ /^__/ || m.to_s == 'object_id' }.each { |m| undef_method m }
+class It < BlankSlate
 
   def initialize
     @methods = []


### PR DESCRIPTION
Instead of repeating the same method undefining code as BlankSlate, just inherit from it.

Is there any reason not to do this? Seems more DRY and with BlankSlate defined by hobo I don't see a dependency risk.
