### PR TITLE
Fix Stringify error with Chrome and Push State requests

### DIFF
--- a/hobo_jquery/vendor/assets/javascripts/hobo-jquery/hjq.js
+++ b/hobo_jquery/vendor/assets/javascripts/hobo-jquery/hjq.js
@@ -236,7 +236,6 @@
                 }
             }
 
-            result.context = this;
             result.type = o.type || 'GET';
             result.data = {};
             /* These are now the defaults, so we don't need to send


### PR DESCRIPTION
I think I found a bug with the push-state support (http://hobocentral.net/manual/changes20#push-state).

It works with Firefox, but if you try it with Chromium, you will see an error in console and the request won't be made with Ajax. The error is `TypeError: Converting circular structure to JSON`.

Using the debugger, I've isolated it to the moment when historyjs saves the state as JSON in the browser. It uses the function `JSON.stringify`. This function is browser dependent, and that's the reason why it works with Firefox but not with Chrome.

The problem lies in the ajax_options object. This object has a reference to itself called `context`, provoking the circular structure error. I just removed this reference and push-state is working in all browsers :). I don't think `context` is being used elsewhere, but I might be wrong.
