### PR TITLE
Closes #34. Use bundle update in wizard in order to correctly resolve jquery_rails dependency

### DIFF
--- a/hobo/lib/generators/hobo/install_default_plugins/install_default_plugins_generator.rb
+++ b/hobo/lib/generators/hobo/install_default_plugins/install_default_plugins_generator.rb
@@ -31,7 +31,7 @@ module Hobo
       unless opts[:skip_gem]
         gem_with_comments("jquery-ui-themes", "~> 0.0.4")
         Bundler.with_clean_env do
-          run "bundle install"
+          run "bundle update"
         end
       end
 


### PR DESCRIPTION
I have tried upgrading to jquery_rails 3.0, but they have stopped including jquery_ui. Instead they recomment using jquery-ui-rails, and in turn we'd have to modify application.js and test that the jquery ui templates work correctly. It can be done, but I guess this change would make sense in the Rails 4 branch.

As a workaround, I suggest we exchange this "bundle install" for "bundle update", and push "Hobo 2.0.1". This way new users will be able to install Hobo without an ugly error :).

What do you think? @bryanlarsen , @Barquin 
