### PR TITLE
Fix the usage of name one inside of input_many

### DIFF
--- a/hobo_jquery/vendor/assets/javascripts/hobo-jquery/hjq-input-many.js
+++ b/hobo_jquery/vendor/assets/javascripts/hobo-jquery/hjq-input-many.js
@@ -24,7 +24,7 @@ if(!RegExp.escape) {
             var me = $(this).parent().parent();
             var top = me.parent();
             var template = top.children("li.input-many-template");
-            var clone = template.clone(true).removeClass("input-many-template");
+            var clone = template.clone().removeClass("input-many-template");
             var attrs = top.data('rapid')['input-many'];
 
             // length-2 because ignore the template li and the empty li


### PR DESCRIPTION
`name_one` inputs (both bootstrap and jquery_ui versions) don't work inside an input_many. 
It looks like they are incompatible with the clone(true) method. Using clone() fixes the issue. 

The "true" option enables the cloning of events. I have tested this solution a bit and I haven't found any problem.

References:
- http://jsfiddle.net/aJdn8/  (you can play with true and false and see the result)
- http://stackoverflow.com/questions/13664020/jquery-autocomplete-and-clone
