### PR TITLE
Update model.rb

### DIFF
--- a/hobo/lib/hobo/controller/model.rb
+++ b/hobo/lib/hobo/controller/model.rb
@@ -341,7 +341,7 @@ module Hobo
         hash = args.extract_options!
         db_sort_field = (hash[field] || hash[field.to_sym] || (field if field.in?(args) || field.to_sym.in?(args))).to_s
 
-        if db_sort_field
+        if db_sort_field.empty?
           if db_sort_field == field && field.match(/\./)
             fields = field.split(".", 2)
             db_sort_field = "#{fields[0].pluralize}.#{fields[1]}"


### PR DESCRIPTION
сhange `parse_sort_param` has to check for `db_sort_field.empty?` not just `db_sort_field`

`db_sort_field` is _String_ (.to_s), so if we want condition to has any sense we should to check for `empty?` string, because any _String_ (even "") will evaluate as true.
