### PR TITLE
Update search_filter.dryml

### DIFF
--- a/hobo_rapid/taglibs/plus/search_filter.dryml
+++ b/hobo_rapid/taglibs/plus/search_filter.dryml
@@ -6,10 +6,10 @@
     <submit label="&t('hobo.table_plus.submit_label', :default=>'Go')" class="search-button" param="search-submit"/>
   </form>
   <if test="&params[:search]">
-    <form param="clear-form" method="get" action="" merge-attrs>
+    <form param="clear-form" method="get" action="" with="&nil" merge-attrs>
       <hidden-fields for-query-string skip="page, search"/>
       <input type="hidden" name="search" value=""/>
-      <submit label="Clear" class="search-button" param="clear-submit"/>
+      <submit label="&t('hobo.table_plus.clear_label', :default=>'Clear')" class="search-button" param="clear-submit"/>
     </form>
   </if>
 </def>


### PR DESCRIPTION
- change `clear-form` set context to `nil` same as for `search-form` - There is problem when in ajax mode, form may be generated as `enctype="multipart/form-data"` so no ajax will work
- label for `clear-submit` internationalization change
