### PR TITLE
OpenSSL::Digest::Digest deprecated fix

### DIFF
--- a/dryml/lib/dryml/part_context.rb
+++ b/dryml/lib/dryml/part_context.rb
@@ -91,7 +91,7 @@
       def generate_digest(data, session)
         secret = self.class.secret || Rails.application.config.secret_key_base || Rails.application.config.secret_token
         key = secret.respond_to?(:call) ? secret.call(session) : secret
-        OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new(self.class.digest), key, data)
+        OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new(self.class.digest), key, data)
       end
 
 


### PR DESCRIPTION
Digest::Digest is deprecated; use Digest

https://github.com/ruby/ruby/pull/446
