### PR TITLE
parse_sort_param handles field with a number

### DIFF
--- a/hobo/lib/hobo/controller/model.rb
+++ b/hobo/lib/hobo/controller/model.rb
@@ -335,7 +335,7 @@ module Hobo
 
 
     def parse_sort_param(*args)
-      _, desc, field = *params[:sort]._?.match(/^(-)?([a-z_]+(?:\.[a-z_]+)?)$/)
+      _, desc, field = *params[:sort]._?.match(/^(-)?([a-z0-9_]+(?:\.[a-z0-9_]+)?)$/)
 
       if field
         hash = args.extract_options!


### PR DESCRIPTION
RegEx didn't permit fields with a number, e.g. custom_label_1.
