### PR TITLE
Add comment to User model's field list about adding new fields, attr_accessible & only_changed?

### DIFF
--- a/hobo/lib/generators/hobo/user_model/templates/model_injection.rb.erb
+++ b/hobo/lib/generators/hobo/user_model/templates/model_injection.rb.erb
@@ -4,7 +4,8 @@
   fields do
 
     # NOTE: If you add fields here, you may need to include them in both the attr_accessible list, and
-    # the list of fields passed to 'only_changed?' in the update_permitted? method for them to appear on the user#edit form.
+    # the list of fields passed to 'only_changed?' in the update_permitted? method for them to appear 
+    # on the user#edit form.
 
     name          :string, :required, :unique
     email_address :email_address, :login => true


### PR DESCRIPTION
When migrating an existing app to Hobo 2.1.2/Rails 4, the new `attr_accessible` requirement combined with `only_changed?` tripped me up a bit. I lost time trying to figure out why new fields weren't showing up on my User#edit form. It wasn't immediately obvious that I _ALSO_ needed include the fields within the list of fields passed to `only_changed?` in the `update_permitted?` method. This comment could save new users some grief. 
