### PR TITLE
Fixes #150: Made handling of scope and options arguments for belongs_to and has_many...

### DIFF
--- a/hobo/lib/hobo/model.rb
+++ b/hobo/lib/hobo/model.rb
@@ -132,13 +132,29 @@ module Hobo
         names += public_instance_methods.*.to_s
       end
 
-      def belongs_to_with_creator_metadata(name, options={}, &block)
+      def belongs_to_with_creator_metadata(name, *args, &block)
+        if args.size == 0 || (args.size == 1 && args[0].kind_of?(Proc))
+            options = {}
+            args.push(options)
+        elsif args.size == 1
+            options = args[0]
+        else
+            options = args[1]
+        end
         self.creator_attribute = name.to_sym if options.delete(:creator)
-        belongs_to_without_creator_metadata(name, options, &block)
+        belongs_to_without_creator_metadata(name, *args, &block)
       end
 
-      def belongs_to_with_test_methods(name, options={}, &block)
-        belongs_to_without_test_methods(name, options, &block)
+      def belongs_to_with_test_methods(name, *args, &block)
+        if args.size == 0 || (args.size == 1 && args[0].kind_of?(Proc))
+            options = {}
+            args.push(options)
+        elsif args.size == 1
+            options = args[0]
+        else
+            options = args[1]
+        end
+        belongs_to_without_test_methods(name, *args, &block)
         refl = reflections[name]
         id_method = refl.options[:primary_key] || refl.klass.primary_key
         if options[:polymorphic]

--- a/hobo/lib/hobo/model/accessible_associations.rb
+++ b/hobo/lib/hobo/model/accessible_associations.rb
@@ -103,21 +103,20 @@ module Hobo
 
       # --- has_many mass assignment support --- #
 
-      def self.has_many_with_accessible(name, received_scope=nil, options={}, &block)
+      def self.has_many_with_accessible(name, *args, &block)
         # Rails 4 supports a lambda as the second argument in a has_many association
         # We need to support it too (required for gems like papertrail)
         # The problem is that when it is not used, the options hash is taken as the scope
         # To fix this, we make a small hack checking the second argument's class
-        if received_scope.is_a?(Proc)
-          has_many_without_accessible(name, received_scope, options, &block)
-        else
-          if received_scope == nil
+        if args.size == 0 || (args.size == 1 && args[0].kind_of?(Proc))
             options = {}
-          else
-            options = received_scope
-          end
-          has_many_without_accessible(name, options, &block)
+            args.push(options)
+        elsif args.size == 1
+            options = args[0]
+        else
+            options = args[1]
         end
+        has_many_without_accessible(name, *args, &block)
         # End of the received_scope hack
 
         if options[:accessible]
@@ -138,8 +137,16 @@ module Hobo
 
       # --- belongs_to assignment support --- #
 
-      def self.belongs_to_with_accessible(name, options={}, &block)
-        belongs_to_without_accessible(name, options, &block)
+      def self.belongs_to_with_accessible(name,*args, &block)
+        if args.size == 0 || (args.size == 1 && args[0].kind_of?(Proc))
+            options = {}
+            args.push(options)
+        elsif args.size == 1
+            options = args[0]
+        else
+            options = args[1]
+        end
+        belongs_to_without_accessible(name,*args, &block)
 
         if options[:accessible]
           class_eval %{

--- a/hobo/lib/hobo/model/permissions.rb
+++ b/hobo/lib/hobo/model/permissions.rb
@@ -79,8 +79,8 @@ module Hobo
         #  ensure active_user gets passed down to :dependent => destroy
         #  associations  (Ticket #528)
 
-        def has_many_with_hobo_permission_check(association_id, scope=nil, options = {}, &extension)
-          has_many_without_hobo_permission_check(association_id, scope, options, &extension)
+        def has_many_with_hobo_permission_check(association_id, *args, &extension)
+          has_many_without_hobo_permission_check(association_id, *args, &extension)
           reflection = reflections[association_id]
           if reflection.options[:dependent]==:destroy
             #overriding dynamic method created in ActiveRecord::Associations#configure_dependency_for_has_many
@@ -91,8 +91,8 @@ module Hobo
           end
         end
 
-        def has_one_with_hobo_permission_check(association_id, scope=nil, options = {}, &extension)
-          has_one_without_hobo_permission_check(association_id, scope, options, &extension)
+        def has_one_with_hobo_permission_check(association_id, *args, &extension)
+          has_one_without_hobo_permission_check(association_id, *args, &extension)
           reflection = reflections[association_id]
           if reflection.options[:dependent]==:destroy
             #overriding dynamic method created in ActiveRecord::Associations#configure_dependency_for_has_one
@@ -106,8 +106,8 @@ module Hobo
           end
         end
 
-        def belongs_to_with_hobo_permission_check(association_id, scope=nil, options = {}, &extension)
-          belongs_to_without_hobo_permission_check(association_id, scope, options, &extension)
+        def belongs_to_with_hobo_permission_check(association_id, *args, &extension)
+          belongs_to_without_hobo_permission_check(association_id, *args, &extension)
           reflection = reflections[association_id]
           if reflection.options[:dependent]==:destroy
             #overriding dynamic method created in ActiveRecord::Associations#configure_dependency_for_belongs_to

--- a/hobo_fields/lib/hobo_fields/model.rb
+++ b/hobo_fields/lib/hobo_fields/model.rb
@@ -82,14 +82,22 @@ module HoboFields
 
 
     # Extend belongs_to so that it creates a FieldSpec for the foreign key
-    def self.belongs_to_with_field_declarations(name, options={}, &block)
+    def self.belongs_to_with_field_declarations(name, *args, &block)
+      if args.size == 0 || (args.size == 1 && args[0].kind_of?(Proc))
+          options = {}
+          args.push(options)
+      elsif args.size == 1
+          options = args[0]
+      else
+          options = args[1]
+      end
       column_options = {}
       column_options[:null] = options.delete(:null) if options.has_key?(:null)
       column_options[:comment] = options.delete(:comment) if options.has_key?(:comment)
 
       index_options = {}
       index_options[:name] = options.delete(:index) if options.has_key?(:index)
-      bt = belongs_to_without_field_declarations(name, options, &block)
+      bt = belongs_to_without_field_declarations(name, *args, &block)
       refl = reflections[name.to_sym]
       fkey = refl.foreign_key
       declare_field(fkey.to_sym, :integer, column_options)


### PR DESCRIPTION
... and has_one wrappings robust and consistent.

Now using *args instead of specifically naming params so that it can be
safely compatible with both rails3 and rails4 (in rails4 the signature of
belongs_to and has_many added an intermediate optional param for scope)

