### PR TITLE
Fix apply_scopes to allow further refinement of result

### DIFF
--- a/hobo/lib/hobo/model/scopes/apply_scopes.rb
+++ b/hobo/lib/hobo/model/scopes/apply_scopes.rb
@@ -7,9 +7,9 @@ module Hobo
           result = self
           scopes.each_pair do |scope, arg|
             if arg.is_a?(Array)
-              result = self.send(scope, *arg) unless arg.first.blank?
+              result = result.send(scope, *arg) unless arg.first.blank?
             else
-              result = self.send(scope, arg) unless arg.blank?
+              result = result.send(scope, arg) unless arg.blank?
             end
           end
           result


### PR DESCRIPTION
```apply_scopes``` should be sending scope to ```result```, not to ```self```, to allow
for repeated calls (further refinement) when multiple scope parameters
are passed. e.g.

http://localhost:3000/admin/entities?status=active&entity_type=corporation

```
scopes.merge!(status_is: params[:status])
scopes.merge!(entity_type_is: params[:entity_type])
```

Further details:
https://groups.google.com/forum/?hl=en#!topic/hobousers/EtgRMr1RAUE