### PR TITLE
Request for review: Add FK constraints to hobo_fields, fix migration escape issues

### DIFF
--- a/hobo_fields/lib/generators/hobo/migration/migration_generator.rb
+++ b/hobo_fields/lib/generators/hobo/migration/migration_generator.rb
@@ -47,6 +47,12 @@ module Hobo
       return if migrations_pending?
 
       generator = Generators::Hobo::Migration::Migrator.new(lambda{|c,d,k,p| extract_renames!(c,d,k,p)})
+
+      unless generator.connection.supports_foreign_keys?
+        action = choose("\n#{generator.connection.adapter_name} adapter does not support foreign keys. You probably should generate the migration using a database adapter which has foreign key support.\n\nGenerate migration [w]ithout foreign keys, or [c]ancel?", /^(w|c)$/)
+        return if action == 'c'
+      end
+
       up, down = generator.generate
 
       if up.blank?

--- a/hobo_fields/lib/generators/hobo/model/templates/model_injection.rb.erb
+++ b/hobo_fields/lib/generators/hobo/model/templates/model_injection.rb.erb
@@ -7,7 +7,7 @@
     timestamps
 <% end -%>
   end
-  attr_accessible <%= accessible_attributes.map {|a| ":#{a}"}.join ", " %>
+  attr_accessible <%= accessible_attributes.map {|a| a.to_sym.inspect}.join ", " %>
 
 <% for bt in bts -%>
   belongs_to :<%= bt %>

--- a/hobo_fields/lib/hobo_fields/extensions/active_record/attribute_methods.rb
+++ b/hobo_fields/lib/hobo_fields/extensions/active_record/attribute_methods.rb
@@ -35,9 +35,9 @@ ActiveRecord::Base.class_eval do
 
     def define_method_attribute=(attr_name)
       if can_wrap_with_hobo_type?(attr_name)
-        src = "begin; wrapper_type = self.class.attr_type(:#{attr_name}); " +
+        src = "begin; wrapper_type = self.class.attr_type(#{attr_name.to_sym.inspect}); " +
           "if !new_value.is_a?(wrapper_type) && HoboFields.can_wrap?(wrapper_type, new_value); wrapper_type.new(new_value); else; new_value; end; end"
-        generated_attribute_methods.module_eval("def #{attr_name}=(new_value); write_attribute('#{attr_name}', #{src}); end", __FILE__, __LINE__)
+        generated_attribute_methods.module_eval("def #{attr_name}=(new_value); write_attribute(#{attr_name.to_s.inspect}, #{src}); end", __FILE__, __LINE__)
       else
         super
       end

--- a/hobo_fields/lib/hobo_fields/model/foreign_key_constraint_spec.rb
+++ b/hobo_fields/lib/hobo_fields/model/foreign_key_constraint_spec.rb
@@ -1,0 +1,67 @@
+module HoboFields
+  module Model
+    class ForeignKeyConstraintSpec
+
+      def initialize(from_model, to_table, options={})
+        @from_model = from_model
+        self.from_table = options.delete(:from_table) || from_model.table_name
+        self.to_table = to_table
+        self.column = options.delete(:column) || default_column
+        self.primary_key = options.delete(:primary_key) || default_primary_key
+        self.on_delete = options.delete(:on_delete) if options[:on_delete]
+        self.on_update = options.delete(:on_update) if options[:on_update]
+        self.name = options.delete(:name) || default_name
+      end
+
+      attr_accessor :from_table, :to_table, :name, :column, :primary_key, :on_delete, :on_update
+
+      # extract ForeignKeyConstraintSpecs from an existing table
+      def self.for_model(model, old_table_name=nil)
+        t = old_table_name || model.table_name
+        model.connection.foreign_keys(t).map do |fkd|
+          self.new(model, fkd.to_table, :from_table => fkd.from_table, :name => fkd.name, :column => fkd.column, :primary_key => fkd.primary_key, :on_delete => fkd.on_delete, :on_update => fkd.on_update) unless model.ignore_fk_constraints.include?(fkd.name)
+        end.compact
+      end
+
+      def default_name
+        # This private Rails method is currently (2015-11-04) the only way to
+        # find the hashed constraint name that Rails automatically generates.
+        @from_model.connection.send(:foreign_key_name, from_table, :column => column)
+      end
+
+      def default_column
+        @from_model.connection.foreign_key_column_for(to_table)
+      end
+
+      def default_primary_key
+        # Rails assumes that the primary key of the target table is 'id' unless otherwise
+        # specified; it doesn't care about any primary_key= calls on the target model, if
+        # there even is one. This is documented in
+        # ActiveRecord::ConnectionAdapters::SchemaStatements::add_foreign_key
+        # and implemented in
+        # ActiveRecord::ConnectionAdapters::ForeignKeyDefinition::default_primary_key
+        "id"
+      end
+
+      def to_add_statement(new_table_name)
+        r = "add_foreign_key #{new_table_name.to_sym.inspect}, #{to_table.to_sym.inspect}"
+        r += ", :column => #{column.inspect}" unless column == default_column
+        r += ", :primary_key => #{primary_key.inspect}" unless primary_key == default_primary_key
+        r += ", :name => #{name.inspect}" if name != default_name
+        r += ", :on_delete => #{on_delete.to_sym.inspect}" if self.on_delete.present?
+        r += ", :on_update => #{on_update.to_sym.inspect}" if self.on_update.present?
+        r
+      end
+
+      def hash
+        [from_table, to_table, name, column, primary_key, on_delete, on_update].hash
+      end
+
+      def ==(v)
+        v.hash == hash
+      end
+      alias_method :eql?, :==
+
+    end
+  end
+end

--- a/hobo_fields/test/migration_generator.rdoctest
+++ b/hobo_fields/test/migration_generator.rdoctest
@@ -223,8 +223,9 @@ Cleanup
 ### Foreign Keys
 
 HoboFields extends the `belongs_to` macro so that it also declares the
-foreign-key field.  It also generates an index on the field.
+foreign-key field.  It also generates an index and foreign key constraint on the field.
 
+        >> class Category < ActiveRecord::Base; end
         >>
          class Advert
            belongs_to :category
@@ -234,10 +235,14 @@ foreign-key field.  It also generates an index on the field.
         =>
          "add_column :adverts, :category_id, :integer
 
-         add_index :adverts, [:category_id]"
+         add_index :adverts, [:category_id]
+
+         add_foreign_key :adverts, :categories"
         >> down
         =>
-         "remove_column :adverts, :category_id
+         "remove_foreign_key :adverts, :categories
+         
+         remove_column :adverts, :category_id
 
          remove_index :adverts, :name => :index_adverts_on_category_id rescue ActiveRecord::StatementInvalid"
 
@@ -246,6 +251,7 @@ Cleanup:
 
         >> Advert.field_specs.delete(:category_id)
         >> Advert.index_specs.delete_if {|spec| spec.fields==["category_id"]}
+        >> Advert.fk_constraint_specs.delete_if {|spec| spec.column=="category_id"}
 {.hidden}
 
 If you specify a custom foreign key, the migration generator observes that:
@@ -259,13 +265,16 @@ If you specify a custom foreign key, the migration generator observes that:
         =>
          "add_column :adverts, :c_id, :integer
 
-         add_index :adverts, [:c_id]"
+         add_index :adverts, [:c_id]
+         
+         add_foreign_key :adverts, :categories, :column => :c_id"
 
 Cleanup:
 {.hidden}
 
         >> Advert.field_specs.delete(:c_id)
         >> Advert.index_specs.delete_if {|spec| spec.fields==["c_id"]}
+        >> Advert.fk_constraint_specs.delete_if {|spec| spec.column=="c_id"}
 {.hidden}
 
 You can avoid generating the index by specifying `:index => false`
@@ -276,13 +285,17 @@ You can avoid generating the index by specifying `:index => false`
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up
-        => "add_column :adverts, :category_id, :integer"
+        =>
+         "add_column :adverts, :category_id, :integer
+
+         add_foreign_key :adverts, :categories"
 
 Cleanup:
 {.hidden}
 
         >> Advert.field_specs.delete(:category_id)
         >> Advert.index_specs.delete_if {|spec| spec.fields==["category_id"]}
+        >> Advert.fk_constraint_specs.delete_if {|spec| spec.column=="category_id"}
 {.hidden}
 
 You can specify the index name with :index
@@ -296,13 +309,81 @@ You can specify the index name with :index
         =>
          "add_column :adverts, :category_id, :integer
 
-         add_index :adverts, [:category_id], :name => 'my_index'"
+         add_index :adverts, [:category_id], :name => \"my_index\"
+
+         add_foreign_key :adverts, :categories"
 
 Cleanup:
 {.hidden}
 
         >> Advert.field_specs.delete(:category_id)
         >> Advert.index_specs.delete_if {|spec| spec.fields==["category_id"]}
+        >> Advert.fk_constraint_specs.delete_if {|spec| spec.column=="category_id"}
+{.hidden}
+
+Similarly, you can avoid or rename the constraint with :foreign_key_constraint
+
+        >>
+         class Advert
+           belongs_to :category, :foreign_key_constraint => false
+         end
+        >> up, down = Generators::Hobo::Migration::Migrator.run
+        >> up
+        =>
+         "add_column :adverts, :category_id, :integer
+
+         add_index :adverts, [:category_id]"
+
+Cleanup:
+{.hidden}
+
+        >> Advert.field_specs.delete(:category_id)
+        >> Advert.index_specs.delete_if {|spec| spec.fields==["category_id"]}
+        >> Advert.fk_constraint_specs.delete_if {|spec| spec.column=="category_id"}
+{.hidden}
+
+        >>
+         class Advert
+           belongs_to :category, :foreign_key_constraint => 'my_constraint'
+         end
+        >> up, down = Generators::Hobo::Migration::Migrator.run
+        >> up
+        =>
+         "add_column :adverts, :category_id, :integer
+
+         add_index :adverts, [:category_id]
+
+         add_foreign_key :adverts, :categories, :name => \"my_constraint\""
+
+Cleanup:
+{.hidden}
+
+        >> Advert.field_specs.delete(:category_id)
+        >> Advert.index_specs.delete_if {|spec| spec.fields==["category_id"]}
+        >> Advert.fk_constraint_specs.delete_if {|spec| spec.column=="category_id"}
+{.hidden}
+
+You can also specify any add_foreign_key options by passing a hash in :foreign_key_constraint
+
+        >>
+         class Advert
+           belongs_to :category, :foreign_key_constraint => { :on_delete => :cascade }
+         end
+        >> up, down = Generators::Hobo::Migration::Migrator.run
+        >> up
+        =>
+         "add_column :adverts, :category_id, :integer
+
+         add_index :adverts, [:category_id]
+
+         add_foreign_key :adverts, :categories, :on_delete => :cascade
+
+Cleanup:
+{.hidden}
+
+        >> Advert.field_specs.delete(:category_id)
+        >> Advert.index_specs.delete_if {|spec| spec.fields==["category_id"]}
+        >> Advert.fk_constraint_specs.delete_if {|spec| spec.column=="category_id"}
 {.hidden}
 
 ### Timestamps
@@ -381,7 +462,7 @@ You can specify the name for the index
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.split("\n")[2]
-        => "add_index :adverts, [:title], :name => 'my_index'"
+        => "add_index :adverts, [:title], :name => \"my_index\""
 
 Cleanup:
 {.hidden}
@@ -413,7 +494,7 @@ The available options for the index function are `:unique` and `:name`
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.split("\n")[2]
-        => "add_index :adverts, [:title], :unique => true, :name => 'my_index'"
+        => "add_index :adverts, [:title], :unique => true, :name => \"my_index\""
 
 Cleanup:
 {.hidden}
@@ -438,6 +519,20 @@ Cleanup:
 {.hidden}
 
 Finally, you can specify that the migration generator should completely ignore an index by passing its name to ignore_index in the model. This is helpful for preserving indices that can't be automatically generated, such as prefix indices in MySQL.
+
+### Foreign key constraints
+
+Although you should rarely need to do so, you can create foreign key constraints directly to a target model, independently of any `belongs_to` association
+
+        >>
+         class Advert
+          foreign_key_constraint :categories
+         end
+        >> up, down = Generators::Hobo::Migration::Migrator.run
+        >> up.split("\n")[2]
+        => "add_foreign_key :adverts, :categories"
+
+Call ignore_foreign_key_constraint on the model to tell the migration generator to ignore an existing constraint.
 
 ### Rename a table
 


### PR DESCRIPTION
Note: This PR is **not ready for merging!** I'm submitting this now just to solicit comments and review.

This PR adds support for foreign key constraints to hobo_fields, to match the feature added in Rails 4.2. Like indexes, constraints are automatically created for `belongs_to` associations, but can be skipped or manually reconfigured with options to `belongs_to`, and can also be explicitly created in model definitions.

Currently, Rails does not have FK constraint support for its sqlite adapter; I'm working on that separately, and this new Hobo feature will not be properly testable until then.

Besides adding foreign key support, I also went through the migration generator code for hobo_fields and changed the way strings were interpolated:
- `"blah blah :#{foo} blah"` is changed to `"blah blah #{foo.to_sym.inspect} blah"` to prevent invalid code from being generated given weird symbols like :"foo bar"
- `"blah blah '#{foo}' blah"` is changed to `"blah blah #{foo.to_s.inspect} blah"` to prevent invalid code from being generated given strings containing single quotes or other escapable characters
