### PR TITLE
more throughly fixed logic error in empty-collection-message that cau…

### DIFF
--- a/hobo_rapid/taglibs/lists/empty_collection_message.dryml
+++ b/hobo_rapid/taglibs/lists/empty_collection_message.dryml
@@ -3,7 +3,7 @@
 The message can be customized via the `empty-collection-message` parameter or by changing the `products.collection.empty_message` translation.
   -->
 <def tag="empty-collection-message">
-  <unless test="&!this.respond_to?('member_class') || this._?.member_class.nil?">
+  <unless test="&!this.respond_to?('member_class') || this._?.member_class.nil? || this._?.member_class==NilClass">
     <div class="empty-collection-message" style="#{'display:none' if !this.empty?}" param="default">
       <ht key="#{this.member_class.name.underscore}.collection.empty_message">
         No <collection-name/> to display


### PR DESCRIPTION
…sed nil dereference crashes when search results were empty.

Now checking both for nil? result and ==NilClass result.
