### PR TITLE
Fix incompatibility with Rails 4.2.5.1 from a change to find_templates

### DIFF
--- a/dryml/lib/dryml/railtie/page_tag_resolver.rb
+++ b/dryml/lib/dryml/railtie/page_tag_resolver.rb
@@ -7,7 +7,7 @@ module Dryml
         super()
       end
 
-      def find_templates(name, prefix, partial, details)
+      def find_templates(name, prefix, partial, details, outside_app_allowed = false)
         tag_name = @controller.dryml_fallback_tag || name.dasherize + '-page'
         method_name = tag_name.to_s.gsub('-', '_')
         if Dryml.empty_page_renderer(@controller.view_context).respond_to?(method_name)


### PR DESCRIPTION
Rails 4.2.5.1 made a change to find_templates. It now takes 5 arguments:

-    def find_templates(name, prefix, partial, details)
+    def find_templates(name, prefix, partial, details, outside_app_allowed = false)

Adapting this resolver to admit the 5th argument.