### PR TITLE
Migration generator misidentifies default: false as changed every time

### DIFF
--- a/hobo_fields/lib/hobo_fields/model/field_spec.rb
+++ b/hobo_fields/lib/hobo_fields/model/field_spec.rb
@@ -97,6 +97,8 @@ module HoboFields
             check_attributes.any? do |k|
               if k==:default && sql_type==:datetime
                 col_spec.default.try.to_datetime != default.try.to_datetime
+              elsif k==:default && sql_type==:boolean
+                col_spec.default.to_s != default.to_s # database stores false as "false"
               else
                 col_spec.send(k) != self.send(k)
               end


### PR DESCRIPTION
If any field has the property default: false, after the first migration
creating the field, all subsequent hobo generated migrations include
a command to change the column to default: false even though it already
has default: false.

This PR fixes the problem which was caused by the database schema
interrogation returning a property of "false" for the default instead of the
boolean value false.

The fix is to specially compare boolean default values by converting
them to strings prior to comparison so that false becomes "false" which
will compare equivalent to "false".

