### PR TITLE
Fix for hobo issue #193 (https://github.com/Hobo/hobo/issues/193)

### DIFF
--- a/hobo_rapid/app/helpers/hobo_rapid_helper.rb
+++ b/hobo_rapid/app/helpers/hobo_rapid_helper.rb
@@ -180,7 +180,11 @@ module HoboRapidHelper
           page_path = if params[:page_path]
                         params[:page_path]
                       else
-                        request.fullpath
+                        if request.query_string.present?
+                          "#{request.path_info}?#{request.query_string}"
+                        else
+                          "#{request.path_info}"
+                        end
                       end
           page_path_hidden = hidden_field_tag("page_path", page_path)
         end

--- a/hobo_support/hobo_support.gemspec
+++ b/hobo_support/hobo_support.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.summary = 'Core Ruby extensions from the Hobo project'
   s.description = 'Core Ruby extensions from the Hobo project'
 
-  s.add_runtime_dependency('rails', ["~> 4.2.7.1"])
+  s.add_runtime_dependency('rails', [">= 4.2.7.1", '< 5.0'])
   # s.add_development_dependency('rubydoctest', [">= 0"])
 
   s.files = `git ls-files -x #{name}/* -z`.split("\0")


### PR DESCRIPTION
hot-input throws "no route" exception when relative_url_root is used

Background/steps to recreate
I am integrating a Hobo app with other applications, and need to run it from a non-root directory.
I therefore made changes to config.ru, and the environment files (development.rb and production.rb).

config.ru now looks like:

  require ::File.expand_path('../config/environment', __FILE__)
  map ENV['RAILS_RELATIVE_URL_ROOT'] || "/" do
    run Rails.application
  end

Environment files that need the relative url root (development.rb/production.rb/test.rb)
now have one more line, in order to provide the correct routes for menu links:

  routes.default_url_options= {:script_name => Rails.application.config.relative_url_root}

Now I can start the application:

  env RAILS_RELATIVE_URL_ROOT=/url_test jruby -S rails server

I create a new employee. The new employee dryml page has a hot-input tag. When the triggering selection is made, hot-input doesn't work. The log contains the message:

  ActionController::RoutingError (No route matches "/url_test/employees/new"):
    app/controllers/employees_controller.rb:33:in `new'

All other features seem to work. The employee can still be created if the hot-input failure doesn't affect a required field.

This fix modifies the logic that creates the page_path variable, which previously assigned the request.fullpath to the page_path. It now assigns the fullpath minus the "script_name". The script_name contains the offset from the root directory.