### PR TITLE
Removal of deprecated classes in Ruby 2.4

### DIFF
--- a/hobo_fields/lib/hobo_fields.rb
+++ b/hobo_fields/lib/hobo_fields.rb
@@ -27,11 +27,6 @@ module HoboFields
     :string        => String
   }
 
-  ALIAS_TYPES = {
-    Fixnum => "integer",
-    Bignum => "integer"
-  }
-
   # Provide a lookup for these rather than loading them all preemptively
 
   STANDARD_TYPES = {
@@ -60,7 +55,7 @@ module HoboFields
   end
 
   def to_name(type)
-    field_types.key(type) || ALIAS_TYPES[type]
+    field_types.key(type)
   end
 
   def can_wrap?(type, val)


### PR DESCRIPTION
Both Fixnum and Bignum are deprecated in ruby 2.4